### PR TITLE
Exibir total de Story Points na página de Show do Sprint quando fechado

### DIFF
--- a/app/assets/stylesheets/sprint.scss
+++ b/app/assets/stylesheets/sprint.scss
@@ -73,3 +73,8 @@
 .sprintfy-daily-meeting-disabled {
   color: #bbb !important;
 }
+
+.sprintfy-summary-sps {
+  background: #eeeeee;
+  font-weight: bold
+}

--- a/app/controllers/sprints_controller.rb
+++ b/app/controllers/sprints_controller.rb
@@ -43,6 +43,10 @@ class SprintsController < ApplicationController
   def edit
     @sprint_goal = Goal.new(sprint: @sprint)
     @users = User.all.sort {|a, b| a.name_or_email.downcase <=> b.name_or_email.downcase }
+
+    @sps_done = @sprint.story_points.sum(&:value)
+    @sps_expected = @sprint.story_points.sum(&:expected_value)
+    @percent_sps = (100.0 * @sps_done / @sps_expected).round(2)
   end
 
   def update

--- a/app/views/sprints/edit.html.erb
+++ b/app/views/sprints/edit.html.erb
@@ -167,6 +167,15 @@
             <% end %>
           </tr>
         <% end %>
+        <% if @sprint.closed? %>
+          <tr class='sprintfy-summary-sps'>
+            <td>Total</td>
+            <td><%= @sprint.squad.name %></td>
+            <td>
+              <%= "#{@sps_done} / #{@sps_expected} ( #{@percent_sps} % )" %>
+            </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
 


### PR DESCRIPTION
# Contexto
Na página de visualização de um Sprint específico, não é possível ver de forma sintetizada o total de SPs entregues pela equipe (valor absoluto e relativo). Ao analisar um sprint fechado, esses dados são de grande importância. Esse ticket faz essa implementação.

Issue: https://github.com/ditointernet/sprintfy/issues/55

# Como testar
Executar localmente e acessar a página de algum Sprint já fechado (se não tiver nenhum, basta criar um). Ao final da tabela de Story Points entregues, deve ser mostrado uma linha com total de SPs entregues, mostrando o valor total entregue, o total esperado e o percentual entregue em relação aos esperados, como mostrado na imagem a seguir.

![screenshot from 2017-05-21 23 47 48](https://cloud.githubusercontent.com/assets/7045912/26290846/df2d6f7c-3e80-11e7-8b5c-d7b0442d8870.png)
