### PR TITLE
Relatório de Performance também deveria ser enviado aos membros da equipe ao fechar o Sprint

### DIFF
--- a/app/mailers/squad_manager_mailer.rb
+++ b/app/mailers/squad_manager_mailer.rb
@@ -40,9 +40,9 @@ class SquadManagerMailer < ApplicationMailer
     @daily_meeting_not_done = @sprint.daily_meetings.where(done: false, skip: false)
     @sprint_skipped_days = @sprint.daily_meetings.where(skip: true).count
 
-    recipients = @squad.squad_managers.map do |manager|
-      manager.user.email
-    end
+    managers = @squad.squad_managers.map { |manager| manager.user.email }
+    team_members = @squad.users.map(&:email)
+    recipients = managers.concat(team_members).uniq
 
     subject = "Relatório Sprint \##{@sprint.squad_counter} - Equipe #{@squad.name}"
 


### PR DESCRIPTION
# Contexto
Atualmente, ao fechar um Sprint, um relatório de performance histórica da equipe é enviado para o gestor. Seria de grande valor para os membros da equipe se eles também recebessem esses relatórios, para poderem acompanhar, sprint a sprint, a evolução pessoal e também da equipe como um todo. Esse Pull Request faz a alteração necessária para que isso seja possível.

Issue relacionada: https://github.com/ditointernet/sprintfy/issues/56

# Como testar
1- Criar um sprint definindo a equipe e os gestores;
2- Fechar o Sprint;
3- Ao fechar o sprint, deve ser enviado, para os gestores e também para os membros da equipe, o relatório contendo informações sobre o desempenho histórico da equipe.