### PR TITLE
Adicionar coluna de SPs prometidos na tela de fechar sprint

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,11 @@ $family-primary: 'Roboto', sans-serif;
 .is-brand {
   color: white !important;
 }
+
+.table th {
+  text-align: center
+}
+
+.table td {
+  text-align: center
+}

--- a/app/assets/stylesheets/sprint.scss
+++ b/app/assets/stylesheets/sprint.scss
@@ -78,3 +78,7 @@
   background: #eeeeee;
   font-weight: bold
 }
+
+.sprintfy-closing-table-center {
+  text-align: center;
+}

--- a/app/views/sprints/closing.html.erb
+++ b/app/views/sprints/closing.html.erb
@@ -9,18 +9,28 @@
         <table class="table is-bordered">
           <thead>
             <tr>
-              <th>Nome</th>
-              <th>Story Points</th>
+              <th></th>
+              <th colspan="2" scope='colgroup' class="sprintfy-closing-table-center">
+                StoryPoints
+              </th>
+            </tr>
+            <tr>
+              <th scope='colgroup'>Name</th>
+              <th scope='col'>Expected</th>
+              <th scope='col'>Done</th>
             </tr>
           </thead>
 
           <tbody>
-            <% @sprint.users.each do |user| %>
+            <% @sprint.story_points.each do |sp| %>
               <tr>
-                <td><%= user.name_or_email %></td>
+                <td><%= sp.user.name_or_email %></td>
+                <td class='sprintfy-closing-table-center'>
+                  <%= sp.expected_value %>
+                </td>
                 <td>
-                  <%= hidden_field_tag "users[][id]", user.id %>
-                  <%= number_field_tag "users[][story_points]", '', step: '0.01', style: 'width: 30%', class: 'input', value: '0' %>
+                  <%= hidden_field_tag "users[][id]", sp.user.id %>
+                  <%= number_field_tag "users[][story_points]", '', step: '0.01', style: 'width: 80%', class: 'input', value: sp.expected_value, :step => 0.25 %>
                 </td>
               </tr>
             <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,31 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Creates users
+user1 = User.create(name: 'Test User 1', email: 'user1@test.com', password: 'mypass')
+user2 = User.create(name: 'Test User 2', email: 'user2@test.com', password: 'mypass')
+user3 = User.create(name: 'Test User 3', email: 'user3@test.com', password: 'mypass')
+
+# Create Squad
+squad = Squad.new(name: 'Squad Test')
+squad.users << user1 << user2 << user3
+squad.save
+
+# Set user1 as manager and give it admin access
+SquadManager.create(user: user1, squad: squad)
+user1.add_role(:admin)
+user1.save
+
+# Create Sprint
+sprint = Sprint.new
+sprint.squad = squad
+sprint.users << user1 << user2 << user3
+sprint.start_date = Date.new(2017, 1, 1)
+sprint.due_date = Date.new(2017, 2, 1)
+sprint.save
+
+# Create Story Points
+StoryPoint.create(sprint: sprint, user: user1, expected_value: 3.0)
+StoryPoint.create(sprint: sprint, user: user2, expected_value: 7.25)
+StoryPoint.create(sprint: sprint, user: user3, expected_value: 5.5)


### PR DESCRIPTION
# Contexto
Atualmente, na tela de fechar um sprint, há um campo de entrada para definir o total de SPs entregues por membro. Esse ticket aprimora a experiência nesse momento em diferentes pontos:
- Cria uma coluna mostrando quantos SPs foram prometidos por membro (para facilitar contexto do sprint0;
- Carrega a página com o total entregue igual ao total prometido (para facilitar edição)
- Seta step padrão das entradas numéricos para 0.25 (era 0.01) (para facilitar edição)
- Cria arquivo com seed para definir estrutura inicial para testes (para facilitar uso)

# Como testar
- Subir o projeto localmente, executar `rake db:seed` para inicializar o banco de dados com os valores iniciais (para usuários, squad, sprint, story points e squad_manager);
- Logar com o usuário com acesso de admin;
- Clicar no sprint ativo e clicar em Finalizar
- Verificar a nova estrutura da tabela de Story Points (com os pontos indicados no contexto acima).

A imagem abaixo mostra a nova estrutura da tabela :smile: 

![screenshot from 2017-06-08 17 06 59](https://user-images.githubusercontent.com/7045912/26948676-9ce41378-4c6d-11e7-870a-36ab8dc6d5b7.png)
