### PR TITLE
Criar menu para usuário ver sua evolução histórica de entregas de SPs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'font-awesome-rails'
 
 gem 'mysql2'
 
+gem 'chartkick'
 
 group :development do
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     bulma-rails (0.2.3)
       sass (~> 3.2)
     byebug (9.0.6)
+    chartkick (2.2.4)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -186,6 +187,7 @@ DEPENDENCIES
   authority
   bulma-rails (~> 0.2.3)
   byebug
+  chartkick
   coffee-rails (~> 4.2)
   devise (~> 4.0)
   font-awesome-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require maskedinput
 //= require_tree .
+//= require chartkick
 
 // App navbar toggle
 $(function() {

--- a/app/controllers/users/pages_controller.rb
+++ b/app/controllers/users/pages_controller.rb
@@ -35,6 +35,10 @@ class Users::PagesController < ApplicationController
     @users = User.order(name: :asc)
   end
 
+  def personal_evolution
+    @chart_data = current_user.personal_evolution_chart_data
+  end
+
   private
 
   def user_params

--- a/app/models/story_point.rb
+++ b/app/models/story_point.rb
@@ -7,4 +7,8 @@ class StoryPoint < ApplicationRecord
 
   validates :sprint, presence: true
   validates :user, presence: true
+
+  scope :by_user_on_sprint, ->(user, sprint) do
+    where(user: user, sprint: sprint).take
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,22 @@ class User < ApplicationRecord
     self.sprints.map(&:sprint_days).map(&:count).reduce(:+)
   end
 
+  def average_sps_per_sprint
+    sprints.each_with_object({}) do |sprint, sps_per_sprint|
+      sprint_name = "#{sprint.squad.name}_#{sprint.squad_counter}"
+      sprint_name = sprint_name.tr(' ', '_')
+      story_points = sprint.story_points.by_user_on_sprint(self, sprint).value
+      sps_per_sprint[sprint_name] = story_points / sprint.total_sprint_days
+    end
+  end
+
+  def personal_evolution_chart_data
+    [
+      name: 'Média de SPs por dia por sprint',
+      data: average_sps_per_sprint
+    ]
+  end
+
   private
 
   def assign_default_role

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
+    <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
@@ -62,6 +63,11 @@
                     <li><%= link_to 'CADASTRADAS', squads_path %></li>
                   </ul>
                 <% end %>
+
+                <p class="menu-label">RELATÓRIOS</p>
+                <ul class="menu-list">
+                  <li><%= link_to 'EVOLUÇÃO PESSOAL', :personal_evolution %></li>
+                </ul>
 
                 <p class="menu-label">CONTA</p>
                 <ul class="menu-list">

--- a/app/views/users/pages/personal_evolution.html.erb
+++ b/app/views/users/pages/personal_evolution.html.erb
@@ -1,0 +1,8 @@
+<%=
+  line_chart @chart_data,
+    title: 'Média de SPs por dia por Sprint',
+    xtitle: "Sprint",
+    ytitle: "SP/dia",
+    curve: false,
+    legend: false
+%>

--- a/app/views/users/pages/personal_evolution.html.erb
+++ b/app/views/users/pages/personal_evolution.html.erb
@@ -1,3 +1,5 @@
+<h1 class="title is-2">RELATÓRIOS</h1>
+<h1 class="title is-3">Evolução Pessoal</h1>
 <%=
   line_chart @chart_data,
     title: 'Média de SPs por dia por Sprint',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,4 +58,5 @@ Rails.application.routes.draw do
   post '/adicionar-usuario', to: 'users/pages#create_user', as: :create_user
   get '/meus-sprints', to: 'users/pages#sprints', as: :user_sprints
   get '/usuarios', to: 'users/pages#list', as: :users_list
+  get '/evolucao', to: 'users/pages#personal_evolution', as: :personal_evolution
 end


### PR DESCRIPTION
# Contexto
Atualmente, temos os dados de desempenho dos membros das equipes no Sprintfy, mas não temos uma forma fácil de visualizar a performance/evolução pessoas. Esse ticket cria um novo menu para **Relatórios**, no qual  usuário poderá ter acesso a diferentes relatórios (futuramente).

Esse ticket implementa o primeiro desses relatórios, que é referente à evolução de entrega média de SPs/dia por Sprint.

# Como testar
Subir o sistema localmente, criar usuários e sprints e verificar a página gerando o relatório com a média de SPs/dia para cada sprint (na ordem de ocorrência dos Sprints, independentemente da equipe).

A figura a seguir mostra um exemplo da página:
![screenshot from 2017-06-09 15 50 38](https://user-images.githubusercontent.com/7045912/26989965-71799636-4d2b-11e7-980d-dd379adacc1c.png)

Issue relacionada: https://github.com/ditointernet/sprintfy/issues/61
