### PR TITLE
PD-2318 Na tela de relatórios incluir SPs de diferentes equipes do usuários

### DIFF
--- a/lib/chart_data.rb
+++ b/lib/chart_data.rb
@@ -10,7 +10,7 @@ class ChartData
   def initialize(params)
     @params = params
     @entry = {}
-    @squad = params[:squad] || get_squad
+    @squad = params[:squad] || nil
   end
 
   def data
@@ -33,10 +33,6 @@ class ChartData
         @entry[Date.today.months_ago(11-i).strftime('%b%y')] = 0
       end
     end
-  end
-
-  def get_squad
-    @params[:person] ? Squad.where(id: User.where(id: @params[:person]).first.squad_id).first.try(:id) : nil
   end
 
   def grouping(sprint)


### PR DESCRIPTION
# Contexto

Atualmente na pesquisa por usuário é considerado somente a equipe atual na busca individual
Pretende-se considerar todos os sprint que o usuário participou, mesmo que em diferentes equipes

# Como testar

Acessar o sprintfy em modo local e logar com uma conta de administrador
acessar os relatórios na aba 'Painel Administrativo'
Testar relatórios de diferentes usuários em períodos diferentes de pesquisa e analisar os resultados